### PR TITLE
36 default context

### DIFF
--- a/src/main/groovy/org/lappsgrid/serialization/lif/Container.groovy
+++ b/src/main/groovy/org/lappsgrid/serialization/lif/Container.groovy
@@ -239,6 +239,10 @@ public class Container {
         if (map['@context']) {
             this.context = Utils.deepCopy(map['@context'])
         }
+        else {
+            this.content = Container.REMOTE_CONTEXT
+        }
+        
         this.content = new Content()//value:map.text.value, language:map.text.language)
         this.text = map.text['@value']
         this.language = map.text['@language']

--- a/src/main/groovy/org/lappsgrid/serialization/lif/Container.groovy
+++ b/src/main/groovy/org/lappsgrid/serialization/lif/Container.groovy
@@ -240,9 +240,9 @@ public class Container {
             this.context = Utils.deepCopy(map['@context'])
         }
         else {
-            this.content = Container.REMOTE_CONTEXT
+            this.context = Container.REMOTE_CONTEXT
         }
-        
+
         this.content = new Content()//value:map.text.value, language:map.text.language)
         this.text = map.text['@value']
         this.language = map.text['@language']

--- a/src/test/groovy/org/lappsgrid/serialization/ContainerTest.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ContainerTest.groovy
@@ -370,7 +370,7 @@ public class ContainerTest {
         assertEquals(2, container.views.size())
         assertEquals(1, container.views[0].annotations.size())
         assertEquals(1, container.views[1].annotations.size())
-        assertEquals(null, container.context)
+        assertEquals(Container.REMOTE_CONTEXT, container.context)
     }
 
     @Test


### PR DESCRIPTION
The `initFromMap` method, which is called by the map and copy constructors, adds the Container.REMOTE_CONTEXT if a \@context has not been specified.

closes #36 
