### PR TITLE
32 view metadata

### DIFF
--- a/src/main/groovy/org/lappsgrid/serialization/Utils.groovy
+++ b/src/main/groovy/org/lappsgrid/serialization/Utils.groovy
@@ -4,10 +4,17 @@ import org.lappsgrid.serialization.lif.Annotation
 import org.lappsgrid.serialization.lif.Contains
 import org.lappsgrid.serialization.lif.View
 
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
 /**
  * @author Keith Suderman
  */
 class Utils {
+
+    static final ZoneId UTC = ZoneId.of("UTC")
+
     static String deepCopy(String string) {
         return string
     }
@@ -61,4 +68,13 @@ class Utils {
     static View deepCopy(View view) {
         return new View(view)
     }
+
+    static String timestamp() {
+        return ZonedDateTime.now(UTC).toString()
+    }
+
+    static ZonedDateTime parseTime(String time) {
+        return ZonedDateTime.parse(time)
+    }
+
 }

--- a/src/main/groovy/org/lappsgrid/serialization/lif/Contains.groovy
+++ b/src/main/groovy/org/lappsgrid/serialization/lif/Contains.groovy
@@ -49,6 +49,8 @@ class Contains {
     @Delegate
     HashMap data = new HashMap()
 
+//    List<DependsOn> dependencies = []
+
     @JsonProperty
     void setUrl(String url) {
         data.url = url
@@ -72,22 +74,10 @@ class Contains {
 
     }
 
-//    @JsonIgnore
-//    void setAtType(String atType) {
-//        this.atType = atType
-//    }
-//
-//    @JsonIgnore
-//    String getAtType() {
-//        return this.atType
-//    }
-
     @JsonProperty
     void setTagSet(String value) throws LifException {
-//        println "Setting tagset to $value"
         if (tagsetKeys.containsKey(getAtType())) {
             String key = tagsetKeys[getAtType()]
-            println "Setting $key to $value"
             data[key] = value
         } else {
             throw new LifException("No tagset-like feature is defined for ${this.atType} ")
@@ -105,27 +95,34 @@ class Contains {
         }
     }
 
-//    @JsonProperty
-//    void setDependsOn(List<DependsOn> dependsOn) {
-//        data.dependsOn = dependsOn
-//    }
-//    List<DependsOn> getDependsOn() {
-//        return data.dependsOn
-//    }
-//    void dependOn(String view, String type) {
-//        List<DependsOn> list = data.dependsOn
-//        if (list == null) {
-//            list = new ArrayList<DependsOn>()
-//            data.dependsOn = list
-//        }
-//        list << new DependsOn(view, [ type ])
-//    }
-//    void dependsOn(String view, List<String> types) {
-//        List<DependsOn> list = data.dependsOn
-//        if (list == null) {
-//            list = new ArrayList<DependsOn>()
-//            data.dependsOn = list
-//        }
-//        list << new DependsOn(view, types)
-//    }
+    @JsonProperty
+    void setDependsOn(List<Dependency> dependsOn) {
+        data.dependsOn = dependsOn
+    }
+
+    List<Dependency> getDependsOn() {
+        return data.dependsOn
+    }
+
+    @JsonProperty
+    void setTimestamp(String timestamp) {
+        data.timestamp = timestamp
+    }
+
+    String getTimestamp() {
+        return data.timestamp
+    }
+
+    void dependency(String view, String type) {
+        dependency(new Dependency(view, type))
+    }
+
+    void dependency(Dependency dependency) {
+        List<Dependency> dependencies = data.dependsOn
+        if (dependencies == null) {
+            dependencies = []
+            data.dependsOn = dependencies
+        }
+        dependencies.add(dependency)
+    }
 }

--- a/src/main/groovy/org/lappsgrid/serialization/lif/Contains.groovy
+++ b/src/main/groovy/org/lappsgrid/serialization/lif/Contains.groovy
@@ -104,15 +104,6 @@ class Contains {
         return data.dependsOn
     }
 
-    @JsonProperty
-    void setTimestamp(String timestamp) {
-        data.timestamp = timestamp
-    }
-
-    String getTimestamp() {
-        return data.timestamp
-    }
-
     void dependency(String view, String type) {
         dependency(new Dependency(view, type))
     }

--- a/src/main/groovy/org/lappsgrid/serialization/lif/Dependency.groovy
+++ b/src/main/groovy/org/lappsgrid/serialization/lif/Dependency.groovy
@@ -22,7 +22,8 @@ import groovy.transform.Canonical
  * @author Keith Suderman
  */
 @Canonical
-class DependsOn {
+class Dependency {
     String view
-    List<String> type
+    String type
+
 }

--- a/src/main/groovy/org/lappsgrid/serialization/lif/View.groovy
+++ b/src/main/groovy/org/lappsgrid/serialization/lif/View.groovy
@@ -19,6 +19,8 @@ package org.lappsgrid.serialization.lif
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import org.lappsgrid.serialization.Utils
 
+import java.time.LocalDateTime
+
 /**
  * A View consists of some metadata and a list of annotations.
  * <p>
@@ -51,6 +53,7 @@ public class View {
     public View() {
         metadata = [:]
         annotations = []
+        this.metadata.timestamp = View.timestamp()
     }
 
     public View(String id) {
@@ -73,12 +76,14 @@ public class View {
         map.annotations.each { a ->
             annotations << new Annotation(a)
         }
+        this.metadata.timestamp = View.timestamp()
     }
 
     public View(View view) {
         this.id = view.id
         this.metadata = Utils.deepCopy(view.metadata)
         this.annotations = Utils.deepCopy(view.annotations)
+        this.metadata.timestamp = View.timestamp()
     }
 
     /**
@@ -156,7 +161,6 @@ public class View {
      * @param type The annotation type. Currently this field is under-defined.
      */
     Contains addContains(String name, String producer, String type) {
-//        ValueObject containsType = new ValueObject(type:type, value:value)
         if (metadata.contains == null) {
             metadata.contains = [:]
         }
@@ -173,4 +177,23 @@ public class View {
         return annotations.findAll { it.atType == type }
     }
 
+    String getTimestamp() {
+        return metadata.timestamp
+    }
+
+    void setTimestamp() {
+        setTimestamp(View.timestamp())
+    }
+
+    void setTimestamp(String time) {
+        metadata.timestamp = time
+    }
+
+    static String timestamp() {
+        return LocalDateTime.now().toString()
+    }
+
+    static LocalDateTime parseTime(String time) {
+        return LocalDateTime.parse(time)
+    }
 }

--- a/src/main/groovy/org/lappsgrid/serialization/lif/View.groovy
+++ b/src/main/groovy/org/lappsgrid/serialization/lif/View.groovy
@@ -16,10 +16,13 @@
  */
 package org.lappsgrid.serialization.lif
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import org.lappsgrid.serialization.Utils
 
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 /**
  * A View consists of some metadata and a list of annotations.
@@ -53,7 +56,7 @@ public class View {
     public View() {
         metadata = [:]
         annotations = []
-        this.metadata.timestamp = View.timestamp()
+        this.setTimestamp()
     }
 
     public View(String id) {
@@ -67,23 +70,18 @@ public class View {
         }
         this.id = map['id']
         this.metadata = Utils.deepCopy(map.metadata)
-//        metadata = [:]
-//        map.metadata.each { name, value ->
-//            metadata[name] = value
-//        }
-        //annotations = map.annotations
         annotations = []
         map.annotations.each { a ->
             annotations << new Annotation(a)
         }
-        this.metadata.timestamp = View.timestamp()
+        this.setTimestamp()
     }
 
     public View(View view) {
         this.id = view.id
         this.metadata = Utils.deepCopy(view.metadata)
         this.annotations = Utils.deepCopy(view.annotations)
-        this.metadata.timestamp = View.timestamp()
+        this.setTimestamp()
     }
 
     /**
@@ -177,23 +175,17 @@ public class View {
         return annotations.findAll { it.atType == type }
     }
 
+    @JsonIgnore
     String getTimestamp() {
         return metadata.timestamp
     }
 
     void setTimestamp() {
-        setTimestamp(View.timestamp())
+        setTimestamp(Utils.timestamp())
     }
 
     void setTimestamp(String time) {
-        metadata.timestamp = time
+        this.metadata.timestamp = time
     }
 
-    static String timestamp() {
-        return LocalDateTime.now().toString()
-    }
-
-    static LocalDateTime parseTime(String time) {
-        return LocalDateTime.parse(time)
-    }
 }

--- a/src/test/groovy/org/lappsgrid/serialization/AnnotationTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/AnnotationTests.groovy
@@ -3,8 +3,6 @@ package org.lappsgrid.serialization
 import org.junit.*
 import org.lappsgrid.discriminator.Discriminators
 import org.lappsgrid.serialization.lif.Annotation
-import org.lappsgrid.serialization.lif.Container
-import org.lappsgrid.serialization.lif.View
 
 import static org.junit.Assert.*
 

--- a/src/test/groovy/org/lappsgrid/serialization/ContainerFactory.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ContainerFactory.groovy
@@ -17,7 +17,6 @@
 
 package org.lappsgrid.serialization
 
-import org.lappsgrid.serialization.lif.Annotation
 import org.lappsgrid.serialization.lif.Container
 import org.lappsgrid.serialization.lif.View
 

--- a/src/test/groovy/org/lappsgrid/serialization/ContainerTest.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ContainerTest.groovy
@@ -21,6 +21,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
+
+import static org.junit.Assert.assertNotEquals
 import static org.lappsgrid.discriminator.Discriminators.Uri
 import org.lappsgrid.serialization.lif.Container.ContextType
 import org.lappsgrid.serialization.lif.Annotation
@@ -242,9 +244,10 @@ public class ContainerTest {
         View v1 = container.views[0]
         View v2 = copy.views[0]
         assertEquals v1.id, v2.id
-        assertEquals 1, v2.metadata.size()
+        assertEquals 2, v2.metadata.size()
         assertNotNull v2.metadata['contains']
         assertNotNull v2.metadata.contains.words
+        assertNotEquals(v1.getTimestamp(), v2.getTimestamp())
         assertEquals 'tests', v2.metadata.contains.words.producer
         assertEquals 'string', v2.metadata.contains.words.type
         assertEquals 2, v2.annotations.size()

--- a/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
@@ -161,7 +161,7 @@ class ContainsTests {
         c.dependency("v2", Uri.NE)
         c.timestamp = LocalDateTime.now().toString()
 
-        println Serializer.toPrettyJson(view)
+        println Serializer.toPrettyJson(c)
 
     }
 

--- a/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
@@ -16,20 +16,22 @@
 
 package org.lappsgrid.serialization
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.lappsgrid.serialization.lif.Dependency
+import org.lappsgrid.serialization.lif.View
 
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 import static org.lappsgrid.discriminator.Discriminators.*
 
 import static org.junit.Assert.*
 
 import org.lappsgrid.serialization.lif.Contains
-import org.lappsgrid.serialization.lif.View
 
 /**
  * @author Keith Suderman
@@ -144,24 +146,12 @@ class ContainsTests {
         assert Uri.NE == dependency.type
     }
 
-    @Test
-    void timestamp() {
-        Contains c = view.addContains(Uri.TOKEN, "producer", "type")
-        c.timestamp = 'today'
-
-        c = roundTrip(c)
-
-        assert 'today' == c.timestamp
-    }
-
-    @Test
+//    @Test
     void print() {
         Contains c = view.addContains(Uri.RELATION, "producer", "type")
         c.dependency("v1", Uri.TOKEN)
         c.dependency("v2", Uri.NE)
-
         println Serializer.toPrettyJson(view)
-        println "Hello world."
     }
 
     // Serialize to a JSON string and then parse it back into an object.
@@ -173,3 +163,10 @@ class ContainsTests {
         return con
     }
 }
+
+//@JsonPropertyOrder(["id", "metadata", "annotations"])
+//class WTF {
+//    String id
+//    Map annotations = [:]
+//    Map metadata = [:]
+//}

--- a/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
@@ -19,7 +19,12 @@ package org.lappsgrid.serialization
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.lappsgrid.discriminator.Discriminators
+import org.lappsgrid.serialization.lif.Dependency
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+import static org.lappsgrid.discriminator.Discriminators.*
 
 import static org.junit.Assert.*
 
@@ -58,18 +63,18 @@ class ContainsTests {
 
     @Test
     void allFieldsWithHelpers() {
-        Contains c = view.addContains(Discriminators.Uri.POS, 'producer', 'type')
+        Contains c = view.addContains(Uri.POS, 'producer', 'type')
         assert 2 == c.size()
         c.url = 'url'
-        c.setTagSet('tagSet')
-//        c.tagSet = 'tagSet'
-        c.dependsOn = [view:'v1', type:'T2']
+        c.tagSet = 'tagSet'
+        c.dependsOn = [[view:'v1', type: 'T2']]
         assert 5 == c.size()
         assert 'producer' == c.producer
         assert 'type' == c.type
         assert 'url' == c.url
-//        assert 'tagSet' == c.getProperty("posTagSet")
         assert 'tagSet' == c.getTagSet()
+        assert c.dependsOn instanceof List
+        assert c.dependsOn.size() == 1
 
         c = roundTrip(c)
         assert 5 == c.size()
@@ -77,7 +82,7 @@ class ContainsTests {
         assert 'type' == c.type
         assert 'url' == c.url
 //        assert 'tagSet' == c.tagSet
-//        assert 'tagSet' == c.getTagSet()
+        assert 'tagSet' == c.getTagSet()
     }
 
     @Test
@@ -119,14 +124,53 @@ class ContainsTests {
         assert [1,2,3] == c.get('list')
     }
 
+    @Test
+    void dependsOn() {
+        Contains c = view.addContains(Uri.NE, "producer", "type")
+        Dependency dependency = new Dependency("v1", Uri.TOKEN)
+        c.dependency(dependency)
+        c.dependency("v2", Uri.NE)
+        c = roundTrip(c)
+
+        List<Dependency> dependencies = c.getDependsOn()
+        assert 2 == dependencies.size()
+
+        dependency = dependencies[0]
+        assert 'v1' == dependency.view
+        assert Uri.TOKEN == dependency.type
+
+        dependency = dependencies[1]
+        assert 'v2' == dependency.view
+        assert Uri.NE == dependency.type
+    }
+
+    @Test
+    void timestamp() {
+        Contains c = view.addContains(Uri.TOKEN, "producer", "type")
+        c.timestamp = 'today'
+
+        c = roundTrip(c)
+
+        assert 'today' == c.timestamp
+    }
+
+//    @Test
+    void print() {
+        Contains c = view.addContains(Uri.RELATION, "producer", "type")
+        c.dependency("v1", Uri.TOKEN)
+        c.dependency("v2", Uri.NE)
+        c.timestamp = LocalDateTime.now().toString()
+
+        println Serializer.toPrettyJson(view)
+
+    }
+
     // Serialize to a JSON string and then parse it back into an object.
     Contains roundTrip(Contains object) {
-//        println "pre tag set: ${object.getTagSet()}"
         String json = Serializer.toJson(object)
         Contains con = Serializer.parse(json, Contains)
-        // because this 'atType' is a @JsonIgnore
+        // because 'atType' is marked with @JsonIgnore
         con.setAtType(object.getAtType())
-//        println "post tag set: ${object.getTagSet()}"
         return con
     }
 }

--- a/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
@@ -154,15 +154,14 @@ class ContainsTests {
         assert 'today' == c.timestamp
     }
 
-//    @Test
+    @Test
     void print() {
         Contains c = view.addContains(Uri.RELATION, "producer", "type")
         c.dependency("v1", Uri.TOKEN)
         c.dependency("v2", Uri.NE)
-        c.timestamp = LocalDateTime.now().toString()
 
-        println Serializer.toPrettyJson(c)
-
+        println Serializer.toPrettyJson(view)
+        println "Hello world."
     }
 
     // Serialize to a JSON string and then parse it back into an object.

--- a/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ContainsTests.groovy
@@ -146,6 +146,19 @@ class ContainsTests {
         assert Uri.NE == dependency.type
     }
 
+    @Test
+    void tagSets() {
+        Contains c = view.addContains(Uri.POS, "some guy", "type")
+        c.setTagSet("penn")
+        c = view.addContains(Uri.NE, "another guy", "type")
+        c.setTagSet("neset")
+
+        String json = Serializer.toJson(view)
+        Map map = Serializer.parse(json, HashMap)
+        assert 'penn' == map.metadata.contains[Uri.POS].posTagSet
+        assert 'neset' == map.metadata.contains[Uri.NE].namedEntityCategorySet
+    }
+
 //    @Test
     void print() {
         Contains c = view.addContains(Uri.RELATION, "producer", "type")

--- a/src/test/groovy/org/lappsgrid/serialization/QueryTest.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/QueryTest.groovy
@@ -18,7 +18,6 @@
 package org.lappsgrid.serialization
 
 import org.junit.*
-import org.lappsgrid.serialization.lif.Contains
 
 import static org.junit.Assert.*
 

--- a/src/test/groovy/org/lappsgrid/serialization/UtilsTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/UtilsTests.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 The Language Applications Grid
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.lappsgrid.serialization
+
+import org.junit.Test
+
+import java.time.ZonedDateTime
+
+/**
+ *
+ */
+class UtilsTests {
+
+    @Test
+    void timestampTests() {
+        String t = Utils.timestamp()
+        println t
+
+        ZonedDateTime time = Utils.parseTime(t)
+        assert t == time.toString()
+    }
+}

--- a/src/test/groovy/org/lappsgrid/serialization/ViewTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ViewTests.groovy
@@ -103,7 +103,7 @@ class ViewTests {
     @Test
     void containsArbitraryFields() {
         view.addContains('T', 'T.producer', 'T.type')
-        view.metadata.contains['T'].dependsOn = 'v1'
+        view.getContains('T').dependency('v1', 'D')
         println new JsonBuilder(view).toPrettyString()
     }
 

--- a/src/test/groovy/org/lappsgrid/serialization/ViewTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ViewTests.groovy
@@ -6,6 +6,9 @@ import org.lappsgrid.serialization.lif.Annotation
 import org.lappsgrid.serialization.lif.Container
 import org.lappsgrid.serialization.lif.Contains
 import org.lappsgrid.serialization.lif.View
+
+import java.time.ZoneId
+
 import static org.lappsgrid.discriminator.Discriminators.*;
 
 import static org.junit.Assert.*
@@ -132,6 +135,5 @@ class ViewTests {
         assert null != clone.getTimestamp()
         assert v.getTimestamp() != clone.getTimestamp()
     }
-
 
 }

--- a/src/test/groovy/org/lappsgrid/serialization/ViewTests.groovy
+++ b/src/test/groovy/org/lappsgrid/serialization/ViewTests.groovy
@@ -122,4 +122,16 @@ class ViewTests {
             assert i == list.get(i);
         }
     }
+
+    @Test
+    void hasTimestamp() {
+        View v = new View()
+        assert null != v.getTimestamp()
+
+        View clone = new View(v)
+        assert null != clone.getTimestamp()
+        assert v.getTimestamp() != clone.getTimestamp()
+    }
+
+
 }


### PR DESCRIPTION
Adds the `dependsOn` and `timestamp` fields to the `contains` section of a View's metadata.  The JSON looks like:

```json
{
  "dependsOn" : [ {
    "view" : "v1",
    "type" : "http://vocab.lappsgrid.org/Token"
  }, {
    "view" : "v2",
    "type" : "http://vocab.lappsgrid.org/NamedEntity"
  } ],
  "producer" : "producer",
  "type" : "type",
  "timestamp" : "2018-11-10T22:55:13.913"
}
```

The `timestamp` is a String, and in Java 8 it is the value of `LocalDateTime.now().toString()`